### PR TITLE
Modify request headers

### DIFF
--- a/examples/modify-request-headers/append-headers.js
+++ b/examples/modify-request-headers/append-headers.js
@@ -1,0 +1,35 @@
+/**
+ * @summary Intercepts request and appends new headers
+ */
+
+addEventListener('fetch', event => {
+	event.respondWith(fetchAndApply(event.request))
+})
+
+async function fetchAndApply(request) {
+	// Copy request initializer onto new object
+	let newInit = Object.assign({}, request);
+
+	// Copy request headers onto new writable object
+	let requestHeaders = new Headers(request.headers)
+
+	// Create callback function to append new headers
+	const addHeaders = (headerPairs) => {
+		for (var prop in headerPairs) {
+			(requestHeaders).append(prop, `${headerPairs[prop]}`);
+		}
+		return requestHeaders;
+	}
+
+	// Assign new headers to initializer copy
+	newInit.headers = addHeaders({ "X-King-Kong": "Some value", "X-CF-Workers": "Another value" })
+
+	// Create a new request object with original request URI
+	// but initialize it with our modified object
+	const updatedRequest = new Request(request.url, newInit)
+
+	// Uncomment to test your code
+	// console.log(updatedRequest.headers.get('X-CF-Workers')) // returns "Another value"
+
+	return fetch(updatedRequest);
+}

--- a/examples/modify-request-headers/append-headers.js
+++ b/examples/modify-request-headers/append-headers.js
@@ -3,33 +3,36 @@
  */
 
 addEventListener('fetch', event => {
-	event.respondWith(fetchAndApply(event.request))
+  event.respondWith(fetchAndApply(event.request))
 })
 
 async function fetchAndApply(request) {
-	// Copy request initializer onto new object
-	let newInit = Object.assign({}, request);
+  // Copy request initializer onto new object
+  let newInit = Object.assign({}, request);
 
-	// Copy request headers onto new writable object
-	let requestHeaders = new Headers(request.headers)
+  // Copy request headers onto new writable object
+  let requestHeaders = new Headers(request.headers)
 
-	// Create callback function to append new headers
-	const addHeaders = (headerPairs) => {
-		for (var prop in headerPairs) {
-			(requestHeaders).append(prop, `${headerPairs[prop]}`);
-		}
-		return requestHeaders;
-	}
+  // Create callback function to append new headers
+  const addHeaders = (headerPairs) => {
+    for (var prop in headerPairs) {
+      (requestHeaders).append(prop, `${headerPairs[prop]}`);
+    }
+    return requestHeaders;
+  }
 
-	// Assign new headers to initializer copy
-	newInit.headers = addHeaders({ "X-King-Kong": "Some value", "X-CF-Workers": "Another value" })
+  // Assign new headers to initializer copy
+  newInit.headers = addHeaders({
+    "X-King-Kong": "Some value",
+    "X-CF-Workers": "Another value"
+  })
 
-	// Create a new request object with original request URI
-	// but initialize it with our modified object
-	const updatedRequest = new Request(request.url, newInit)
+  // Create a new request object with original request URI
+  // but initialize it with our modified object
+  const updatedRequest = new Request(request.url, newInit)
 
-	// Uncomment to test your code
-	// console.log(updatedRequest.headers.get('X-CF-Workers')) // returns "Another value"
+  // Uncomment to test your code
+  // console.log(updatedRequest.headers.get('X-CF-Workers')) // returns "Another value"
 
-	return fetch(updatedRequest);
+  return fetch(updatedRequest);
 }


### PR DESCRIPTION
This example:

- Clones the `request` init parameter (`newInit`)
- Constructs a writable clone of the request headers
- Creates a callback that accepts an object literal as an argument, then runs a `for...in` loop to append each entry to the new headers object
- Reassigns the headers value on `newInit` by invoking the callback with custom header k-v pairs
- Passes on a (cloned) request with these additional headers