### PR TITLE
Swap the if blocks so that the header becomes optional

### DIFF
--- a/examples/edge-cache-html/edge-cache-html.js
+++ b/examples/edge-cache-html/edge-cache-html.js
@@ -74,6 +74,7 @@ async function processRequest(originalRequest, event) {
         status += ', Purged';
       }
       bypassCache = bypassCache || shouldBypassEdgeCache(request, response);
+
       if ((!options || options.cache) && isHTML &&
           originalRequest.method === 'GET' && response.status === 200 &&
           !bypassCache) {
@@ -123,13 +124,17 @@ async function processRequest(originalRequest, event) {
 function shouldBypassEdgeCache(request, response) {
   let bypassCache = false;
 
-  if (request && response) {
-    const options = getResponseOptions(response);
-    const cookieHeader = request.headers.get('cookie');
+  if (request) {
+
     let bypassCookies = DEFAULT_BYPASS_COOKIES;
-    if (options) {
-      bypassCookies = options.bypassCookies;
+    if (response) {
+      const options = getResponseOptions(response);
+      if (options) {
+        bypassCookies = options.bypassCookies;
+      }
     }
+
+    let cookieHeader = request.headers.get('cookie');
     if (cookieHeader && cookieHeader.length && bypassCookies.length) {
       const cookies = cookieHeader.split(';');
       for (let cookie of cookies) {
@@ -172,7 +177,8 @@ async function getCachedResponse(request) {
     noCache = true;
     status = 'Bypass for Reload';
   }
-  if (!noCache && request.method === 'GET' && accept && accept.indexOf('text/html') >= 0) {
+
+  if (!noCache && request.method === 'GET') {
     // Build the versioned URL for checking the cache
     cacheVer = await GetCurrentCacheVersion(cacheVer);
     const cacheKeyRequest = GenerateCacheRequest(request, cacheVer);
@@ -181,13 +187,14 @@ async function getCachedResponse(request) {
     try {
       let cache = caches.default;
       let cachedResponse = await cache.match(cacheKeyRequest);
+
+      // Check to see if the response needs to be bypassed because of a cookie
+      bypassCache = shouldBypassEdgeCache(request, cachedResponse);
+
       if (cachedResponse) {
         // Copy Response object so that we can edit headers.
         cachedResponse = new Response(cachedResponse.body, cachedResponse);
 
-        // Check to see if the response needs to be bypassed because of a cookie
-        bypassCache = shouldBypassEdgeCache(request, cachedResponse);
-      
         // Copy the original cache headers back and clean up any control headers
         if (bypassCache) {
           status = 'Bypass Cookie';


### PR DESCRIPTION
A very small commit here.

The shouldBypassEdgeCache() method within edge-cache worker requires presence of both request and cached response. In any other case it returns false without using the defaults.

While i do understand the need to support headers, i am not sure that overriding the default will be used at all, or often, especially in the case of wordpress where it is not-at-all trivial to do. Furthermore, i see no edge cases occuring in this way, since we will always force the validation of cookies.